### PR TITLE
[TASK] Improve docRoothPath generation for TYPO3 v11 compatibility

### DIFF
--- a/Classes/Controller/DocModuleController.php
+++ b/Classes/Controller/DocModuleController.php
@@ -40,15 +40,14 @@ class DocModuleController
         $publicResourcesPath = '../../' . PathUtility::getRelativePathTo(ExtensionManagementUtility::extPath('doc')) . 'Resources/Public/docsify/';
 
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-        $uri = $uriBuilder->buildUriFromRoute('ajax_doc_serve');
+        $uri = $uriBuilder->buildUriFromRoute('ajax_doc_serve', ['path' => $docRootPath]);
 
         $templatePathAndFilename = GeneralUtility::getFileAbsFileName('EXT:doc/Resources/Private/Templates/Module.html');
         $view = GeneralUtility::makeInstance(StandaloneView::class);
         $view->setTemplatePathAndFilename($templatePathAndFilename);
         $view->assignMultiple([
             'path' => $publicResourcesPath,
-            'prefix' => $uri,
-            'docRoothPath' => $docRootPath,
+            'docRoothPath' => $uri,
             'documentationName' => $documentationName,
             'darkMode' => $settings['darkMode'] ?? false
         ]);

--- a/Resources/Private/Templates/Module.html
+++ b/Resources/Private/Templates/Module.html
@@ -15,7 +15,7 @@
 <body>
 <div id="app"></div>
 <script>
-    var docRootPath = '{prefix}&path={docRoothPath}';
+    var docRootPath = '{docRoothPath->f:format.htmlentitiesDecode()}';
     var documentationName = '{documentationName}';
     window.$docsify = {
         name: documentationName,


### PR DESCRIPTION
EXT:doc isn't completely TYPO3 v11 compatible yet.
With v11 the `path` parameter is attached to `docRootPath` with `&` instead of `?`:
```
var docRootPath = '/typo3/ajax/doc/serve&path=/typo3conf/ext/mypackage/Resources/Private/Documentation/';
```

This patch mitigates the problem with the hard coded `&` and is tested with v10 and v11.